### PR TITLE
Add base blocking device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -938,7 +938,7 @@ endif
 
 
 ifeq ($(KBUILD_EXTMOD),)
-core-y		+= kernel/ certs/ mm/ fs/ ipc/ security/ crypto/ block/ sys_stack/ sys_hello_world/ sys_stop/
+core-y		+= kernel/ certs/ mm/ fs/ ipc/ security/ crypto/ block/ sys_blocking_dev/ sys_stack/ sys_hello_world/ sys_stop/
 
 vmlinux-dirs	:= $(patsubst %/,%,$(filter %/, $(init-y) $(init-m) \
 		     $(core-y) $(core-m) $(drivers-y) $(drivers-m) \

--- a/arch/arm/tools/syscall.tbl
+++ b/arch/arm/tools/syscall.tbl
@@ -417,3 +417,4 @@
 400	common 	hello_world		sys_hello_world
 401	common	stop_process		sys_stop_process
 402	common 	continue_process	sys_continue_process
+403	common 	write_device		sys_write_device

--- a/sys_blocking_dev/Makefile
+++ b/sys_blocking_dev/Makefile
@@ -1,0 +1,1 @@
+obj-y := sys_blocking_dev.o

--- a/sys_blocking_dev/sys_blocking_dev.c
+++ b/sys_blocking_dev/sys_blocking_dev.c
@@ -1,0 +1,58 @@
+#include <linux/fs.h>
+#include <linux/kernel.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+
+static ssize_t blocking_dev_read(struct file *filp, char __user *buffer,
+	size_t length, loff_t *ppos)
+{
+	return simple_read_from_buffer(buffer, length, ppos, "a", 1);
+}
+
+static ssize_t blocking_dev_write(struct file *filp, const char __user *buffer,
+	size_t length, loff_t *ppos)
+{
+	char module_buffer;
+	int retval;
+
+	if (length != 1)
+		return -EINVAL;
+
+	retval = simple_write_to_buffer(&module_buffer, 1, ppos, buffer, 1);
+	if (!retval || module_buffer != 'a')
+		return -EINVAL;
+	return retval;
+}
+
+static const struct file_operations blocking_dev_fops = {
+	.owner = THIS_MODULE,
+	.read  = blocking_dev_read,
+	.write = blocking_dev_write
+};
+
+static struct miscdevice id_misc_device = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "blocking_dev",
+	.fops = &blocking_dev_fops
+};
+
+static int __init blocking_dev_init(void)
+{
+	int retval;
+
+	retval = misc_register(&id_misc_device);
+	if (retval)
+		pr_err("blocking_dev_dev: misc_register %d\n", retval);
+	return retval;
+}
+
+static void __exit blocking_dev_exit(void)
+{
+	misc_deregister(&id_misc_device);
+}
+
+module_init(blocking_dev_init);
+module_exit(blocking_dev_exit);
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Tiago Koji Castro Shibata <tishi@linux.com>");
+MODULE_DESCRIPTION("Blocking device sample");

--- a/sys_blocking_dev/sys_blocking_dev.c
+++ b/sys_blocking_dev/sys_blocking_dev.c
@@ -1,33 +1,65 @@
 #include <linux/fs.h>
 #include <linux/kernel.h>
+#include <linux/list.h>
 #include <linux/miscdevice.h>
 #include <linux/module.h>
+#include <linux/slab.h>
+
+static DECLARE_WAIT_QUEUE_HEAD(wq);
+static LIST_HEAD(data_queue);
+
+struct device_data {
+	struct list_head head;
+	char data;
+};
+
+static char get_data(void)
+{
+	struct device_data *entry;
+	char c;
+
+	entry = list_first_entry(&data_queue, struct device_data, head);
+	c = entry->data;
+	list_del(&entry->head);
+	kfree(entry);
+	return c;
+}
+
+static long put_data(char c)
+{
+	struct device_data *entry = kmalloc(sizeof(*entry), GFP_KERNEL);
+	if (!entry) {
+		pr_debug("Device queue data allocation failed\n");
+		return -1;
+	}
+	entry->data = c;
+	list_add_tail(&entry->head, &data_queue);
+	return 0;
+}
 
 static ssize_t blocking_dev_read(struct file *filp, char __user *buffer,
 	size_t length, loff_t *ppos)
 {
-	return simple_read_from_buffer(buffer, length, ppos, "a", 1);
+	if (wait_event_interruptible(wq, !list_empty(&data_queue)))
+		return -ERESTARTSYS;
+
+	// FIXME Race condition if multiple readers
+	char c = get_data();
+	return simple_read_from_buffer(buffer, length, ppos, &c, 1);
 }
 
-static ssize_t blocking_dev_write(struct file *filp, const char __user *buffer,
-	size_t length, loff_t *ppos)
+asmlinkage long sys_write_device(int data)
 {
-	char module_buffer;
-	int retval;
-
-	if (length != 1)
-		return -EINVAL;
-
-	retval = simple_write_to_buffer(&module_buffer, 1, ppos, buffer, 1);
-	if (!retval || module_buffer != 'a')
-		return -EINVAL;
-	return retval;
+	int rc = put_data(data);
+	if (rc)
+		return rc;
+	wake_up_interruptible(&wq);
+	return 0;
 }
 
 static const struct file_operations blocking_dev_fops = {
 	.owner = THIS_MODULE,
-	.read  = blocking_dev_read,
-	.write = blocking_dev_write
+	.read  = blocking_dev_read
 };
 
 static struct miscdevice id_misc_device = {


### PR DESCRIPTION
Item 2.2, cria um device e possui callbacks pra `read` e `write`. Pela especificação do projeto o `write` vai acabar não sendo usado (se não formos usar pra testar nada podemos apagar o callback e a entrada em `struct file_operations`).